### PR TITLE
Add some php colors

### DIFF
--- a/colors/palenight.vim
+++ b/colors/palenight.vim
@@ -429,6 +429,25 @@ call s:h("xmlEndTag", { "fg": s:red })
 call s:h("xmlTag", { "fg": s:red })
 call s:h("xmlTagName", { "fg": s:red })
 
+" PHP
+call s:h("phpInclude", { "fg": s:purple })
+call s:h("phpClass", { "fg": s:yellow })
+call s:h("phpClasses", { "fg": s:yellow })
+call s:h("phpFunction", { "fg": s:blue })
+call s:h("phpType", { "fg": s:purple })
+call s:h("phpKeyword", { "fg": s:purple })
+call s:h("phpVarSelector", { "fg": s:white })
+call s:h("phpIdentifier", { "fg": s:white })
+call s:h("phpMethod", { "fg": s:blue })
+call s:h("phpBoolean", { "fg": s:blue })
+call s:h("phpParent", { "fg": s:white })
+call s:h("phpOperator", { "fg": s:purple })
+call s:h("phpRegion", { "fg": s:purple })
+call s:h("phpUseNamespaceSeparator", { "fg": s:white })
+call s:h("phpClassNamespaceSeparator", { "fg": s:white })
+call s:h("phpDocTags", { "fg": s:purple, "gui": "italic", "cterm": "italic" })
+call s:h("phpDocParam", { "fg": s:purple, "gui": "italic", "cterm": "italic" })
+
 " }}}
 
 " Plugin Highlighting {{{


### PR DESCRIPTION
The actual version of PHP colors look like this:

![image](https://user-images.githubusercontent.com/1557305/57185906-038fef80-6ea3-11e9-9158-7bb68fb35391.png)

With this changes (for the people who use 'stanAngeloff/php.vim')

![image](https://user-images.githubusercontent.com/1557305/57185903-f541d380-6ea2-11e9-9ec8-747834ab4f80.png)
