### PR TITLE
make the focused tab more obvious

### DIFF
--- a/autoload/lightline/colorscheme/palenight.vim
+++ b/autoload/lightline/colorscheme/palenight.vim
@@ -36,10 +36,10 @@ let s:p.replace.left    = [ [ s:p_black, s:p_green ], [ s:p_green, s:p_menu_grey
 let s:p.replace.right   = copy(s:p.replace.left)
 let s:p.replace.middle  = copy(s:p.normal.middle)
 
-let s:p.tabline.left    = [ [ s:p_black, s:p_yellow ] ]
-let s:p.tabline.right   = copy(s:p.tabline.left)
+let s:p.tabline.left    = [ [ s:p_yellow, s:p_menu_grey ] ]
+let s:p.tabline.right   = [ [ s:p_black, s:p_yellow ] ]
 let s:p.tabline.middle  = [ [ s:p_black, s:p_menu_grey ] ]
-let s:p.tabline.tabsel  = [ [ s:p_black, s:p_yellow ] ]
+let s:p.tabline.tabsel  = copy(s:p.tabline.right)
 
 let s:p.inactive.left   = [ [ s:p_black, s:p_menu_grey ], [ s:p_black, s:p_menu_grey ] ]
 let s:p.inactive.right  = copy(s:p.inactive.left)


### PR DESCRIPTION
I usually use a few tabs when I'm coding to separate concerns. The main issue I had with the theme is that all the tabs are visually the same. This PR accentuates the selected tab. 