### PR TITLE
Fix lightline configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ colorscheme palenight
 To configure lightline, add the following line:
 
 ```vim
-let g:lightline.colorscheme = 'palenight'
+let g:lightline = { 'colorscheme': 'palenight' }
 ```
 
 To configure airline, add the following line:


### PR DESCRIPTION
When trying to configure the palenight colorscheme using the old instructions, the process fails with this error: undefined variable g:lightline. See: https://github.com/itchyny/lightline.vim/issues/149.

I've changed the instructions for lightline to prevent this error.