### PR TITLE
Add support for termdebug plugin

### DIFF
--- a/colors/palenight.vim
+++ b/colors/palenight.vim
@@ -498,6 +498,10 @@ call s:h("VistaArgs", { "fg": s:comment_grey })
 call s:h("VistaKind", { "fg": s:comment_grey })
 call s:h("VistaScopeKind", { "fg": s:yellow })
 
+" termdebug
+call s:h("debugBreakpoint", { "fg": s:blue_purple })
+call s:h("debugPC", { "bg": s:blue_purple, "fg": s:black })
+
 " }}}
 
 " Git Highlighting {{{


### PR DESCRIPTION
Recent versions of Vim and Neovim ship termdebug, a plugin for integrating gdb.

Closes #26 