### PR TITLE
Add support for jedi-vim

### DIFF
--- a/colors/palenight.vim
+++ b/colors/palenight.vim
@@ -498,6 +498,10 @@ call s:h("VistaArgs", { "fg": s:comment_grey })
 call s:h("VistaKind", { "fg": s:comment_grey })
 call s:h("VistaScopeKind", { "fg": s:yellow })
 
+" davidhalter/jedi-vim
+call s:h("jediFunction", { "bg": s:white_mask_11, "fg": s:white })
+call s:h("jediFat", { "bg": s:white_mask_11, "fg": s:blue })
+
 " }}}
 
 " Git Highlighting {{{


### PR DESCRIPTION
I really like the color scheme!
Thank you for creating it!

So, my suggestion is to add https://github.com/davidhalter/jedi-vim highlighting, how about that?

Thanks!

Before:
<img width="500" alt="before" src="https://user-images.githubusercontent.com/16581287/92321360-48620280-f064-11ea-9ff7-9904f921cfa2.png">

After:
<img width="500" alt="after" src="https://user-images.githubusercontent.com/16581287/92321363-4bf58980-f064-11ea-87c7-b19172b5fb98.png">
