### PR TITLE
autoload: lighten up `special_grey` key

### DIFF
--- a/autoload/palenight.vim
+++ b/autoload/palenight.vim
@@ -22,7 +22,7 @@ let s:colors = {
       \ "cursor_grey": get(s:overrides, "cursor_grey", { "gui": "#2C323C", "cterm": "236", "cterm16": "8" }),
       \ "visual_grey": get(s:overrides, "visual_grey", { "gui": "#3E4452", "cterm": "237", "cterm16": "15" }),
       \ "menu_grey": get(s:overrides, "menu_grey", { "gui": "#3E4452", "cterm": "237", "cterm16": "8" }),
-      \ "special_grey": get(s:overrides, "special_grey", { "gui": "#3B4048", "cterm": "238", "cterm16": "15" }),
+      \ "special_grey": get(s:overrides, "special_grey", { "gui": "#717CB4", "cterm": "243", "cterm16": "15" }),
       \ "vertsplit": get(s:overrides, "vertsplit", { "gui": "#181A1F", "cterm": "59", "cterm16": "15" }),
       \ "white_mask_1": get(s:overrides, "white_mask_1", { "gui": "#333747", "cterm": "237", "cterm16": "15" }),
       \ "white_mask_3": get(s:overrides, "white_mask_3", { "gui": "#474b59", "cterm": "238", "cterm16": "15" }),


### PR DESCRIPTION
For some reason, `special_grey` keeps being used (on highlighting groups inheriting from groups using that color) for text which is almost unreadable given this scheme's background color.

One example are HTML comments in markdown documents.

The new color code is readable as foreground text, but used as selection background in material's palenight theme[1].

[1] https://material-theme.com/docs/reference/color-palette/ (scroll
    down to `palenight`)